### PR TITLE
Save criteria templates

### DIFF
--- a/src/component-actions/list-actions.ts
+++ b/src/component-actions/list-actions.ts
@@ -78,7 +78,8 @@ function setListArchivedState(listId: string, archived: boolean, stateMgr: Short
         store.set('lists', lists);
         stateMgr.setState({
             ...stateMgr.state,
-            lists: lists
+            lists: lists,
+            listToBeDeleted: null
         });
     }
 }

--- a/src/components/bootstrap-icon.tsx
+++ b/src/components/bootstrap-icon.tsx
@@ -8,7 +8,6 @@ type BootstrapIconsProps = React.HTMLAttributes<HTMLSpanElement> & {
  * TODO: await fix for: https://github.com/ismamz/react-bootstrap-icons/issues/39
  */
 export function BootstrapIcon(props: BootstrapIconsProps) {
-    const propsWithoutClassName = {...props};
-    delete propsWithoutClassName.className;
-    return <i className={`bi-${props.icon} ${props.className ?? ''}`} {...propsWithoutClassName}></i>;
+    const {className, ...propsWithoutClassName} = props;
+    return <i className={`bi-${props.icon} ${className ?? ''}`} {...propsWithoutClassName}></i>;
 }

--- a/src/components/shortlist-it-criteria-deletion-modal.tsx
+++ b/src/components/shortlist-it-criteria-deletion-modal.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { ShortlistItStateManager } from "../types/shortlist-it-state-manager";
+import { ShortlistItModal } from "./shortlist-it-modal";
+import { Button } from "react-bootstrap";
+import { store } from "../utilities/storage";
+import { Shortlist } from "../types/shortlist";
+
+type ShortlistItCriteriaDeletionModalProps = {
+    stateMgr: ShortlistItStateManager;
+};
+
+function hideDeleteConfirmation(stateMgr: ShortlistItStateManager) {
+    stateMgr.setState({
+        ...stateMgr.state,
+        criteriaToBeDeleted: null
+    });
+}
+
+function confirmDeletion(criteriaId: string, stateMgr: ShortlistItStateManager): void {
+    const listIndex = stateMgr.state.lists.findIndex(l => l.criteria.find(c => c.id === criteriaId));
+    if (listIndex >= 0) {
+        const list = stateMgr.state.lists[listIndex];
+        const criteriaIndex = list.criteria.findIndex(c => c.id === criteriaId);
+        if (criteriaIndex >= 0) {
+            list.criteria.splice(criteriaIndex, 1);
+            store.set('lists', stateMgr.state.lists);
+            stateMgr.setState({
+                ...stateMgr.state,
+                criteriaToBeDeleted: null
+            });
+        }
+    }
+}
+
+export function ShortlistItCriteriaDeletionModal(props: ShortlistItCriteriaDeletionModalProps) {
+    const criteriaId = props.stateMgr.state.criteriaToBeDeleted;
+    let list: Shortlist;
+    let criteriaName: string;
+    if (criteriaId) {
+        list = props.stateMgr.state.lists.find(l => l.criteria.find(c => c.id === criteriaId) != null);
+        criteriaName = list.criteria.find(l => l.id === criteriaId)?.name;
+    }
+    return (
+        <ShortlistItModal 
+            id={`delete-${criteriaId}`}
+            variant="danger"
+            heading="Warning!"
+            dismissible={true}
+            show={!!(criteriaId && list && criteriaName)}
+            onClose={() => hideDeleteConfirmation(props.stateMgr)}>
+            <p>
+            are you certain you want to delete Criteria named: <i>{criteriaName}</i> from list titled: <i>{list?.title}</i>? once deleted it can not be recovered.
+            </p>
+            <hr />
+            <div className="d-flex justify-content-end">
+                <Button onClick={() => {
+                    confirmDeletion(criteriaId, props.stateMgr);
+                }} variant="outline-danger">
+                    DELETE
+                </Button>
+            </div>
+        </ShortlistItModal>
+    );
+}

--- a/src/components/shortlist-it-criteria-template-deletion-modal.tsx
+++ b/src/components/shortlist-it-criteria-template-deletion-modal.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { ShortlistItStateManager } from "../types/shortlist-it-state-manager";
+import { ShortlistItModal } from "./shortlist-it-modal";
+import { Button } from "react-bootstrap";
+import { store } from "../utilities/storage";
+
+type ShortlistItCriteriaTemplateDeletionModalProps = {
+    stateMgr: ShortlistItStateManager;
+};
+
+function hideDeleteConfirmation(stateMgr: ShortlistItStateManager) {
+    stateMgr.setState({
+        ...stateMgr.state,
+        criteriaTemplateToBeDeleted: null
+    });
+}
+
+function confirmDeletion(templateId: string, stateMgr: ShortlistItStateManager): void {
+    if (stateMgr.state.criteriaTemplates.has(templateId)) {
+        stateMgr.state.criteriaTemplates.delete(templateId);
+        store.set('criteriaTemplates', stateMgr.state.criteriaTemplates);
+        stateMgr.setState({
+            ...stateMgr.state,
+            criteriaTemplateToBeDeleted: null
+        });
+    }
+}
+
+export function ShortlistItCriteriaTemplateDeletionModal(props: ShortlistItCriteriaTemplateDeletionModalProps) {
+    const templateId = props.stateMgr.state.criteriaTemplateToBeDeleted;
+    return (
+        <ShortlistItModal 
+            id={`delete-${templateId}`}
+            variant="danger"
+            heading="Warning!"
+            dismissible={true}
+            show={!!(templateId && props.stateMgr.state.criteriaTemplates.has(templateId))}
+            onClose={() => hideDeleteConfirmation(props.stateMgr)}>
+            <p>
+            are you certain you want to delete Criteria Template named: <i>{templateId}</i>? once deleted it can not be recovered.
+            </p>
+            <hr />
+            <div className="d-flex justify-content-end">
+                <Button onClick={() => {
+                    confirmDeletion(templateId, props.stateMgr);
+                }} variant="outline-danger">
+                    DELETE
+                </Button>
+            </div>
+        </ShortlistItModal>
+    );
+}

--- a/src/components/shortlist-it-criteria-template-item.tsx
+++ b/src/components/shortlist-it-criteria-template-item.tsx
@@ -1,22 +1,16 @@
 import { Badge, Dropdown } from "react-bootstrap";
 import { Criteria } from "../types/criteria/criteria";
 import { ShortlistItStateManager } from "../types/shortlist-it-state-manager";
-import { store } from "../utilities/storage";
 import { BootstrapIcon } from "./bootstrap-icon";
 import React from "react";
 import { addNewCriteria } from "./shortlist-it-list-criteria-add-new-dropdown";
 import { Shortlist } from "../types/shortlist";
 
 function deleteCriteriaTemplate(templateId: string, stateMgr: ShortlistItStateManager): void {
-    if (confirm(`are you sure you want to delete Criteria Template: '${templateId}'?`)) {
-        const criteriaTemplates = stateMgr.state.criteriaTemplates;
-        criteriaTemplates.delete(templateId);
-        store.set('criteriaTemplates', criteriaTemplates);
-        stateMgr.setState({
-            ...stateMgr.state,
-            criteriaTemplates: criteriaTemplates
-        });
-    }
+    stateMgr.setState({
+        ...stateMgr.state,
+        criteriaTemplateToBeDeleted: templateId
+    });
 }
 
 type ShortlistItCriteriaTemplateItemProps = {

--- a/src/components/shortlist-it-criteria-template-item.tsx
+++ b/src/components/shortlist-it-criteria-template-item.tsx
@@ -1,0 +1,45 @@
+import { Badge, Dropdown } from "react-bootstrap";
+import { Criteria } from "../types/criteria/criteria";
+import { ShortlistItStateManager } from "../types/shortlist-it-state-manager";
+import { store } from "../utilities/storage";
+import { BootstrapIcon } from "./bootstrap-icon";
+import React from "react";
+import { addNewCriteria } from "./shortlist-it-list-criteria-add-new-dropdown";
+import { Shortlist } from "../types/shortlist";
+
+function deleteCriteriaTemplate(templateId: string, stateMgr: ShortlistItStateManager): void {
+    if (confirm(`are you sure you want to delete Criteria Template: '${templateId}'?`)) {
+        const criteriaTemplates = stateMgr.state.criteriaTemplates;
+        criteriaTemplates.delete(templateId);
+        store.set('criteriaTemplates', criteriaTemplates);
+        stateMgr.setState({
+            ...stateMgr.state,
+            criteriaTemplates: criteriaTemplates
+        });
+    }
+}
+
+type ShortlistItCriteriaTemplateItemProps = {
+    stateMgr: ShortlistItStateManager;
+    list: Shortlist;
+    template: Omit<Criteria, 'id'>;
+};
+
+export default function ShortlistItCriteriaTemplateItem(props: ShortlistItCriteriaTemplateItemProps) {
+    return (
+        <Dropdown.Item key={props.template.name} onClick={() => null}>
+            <div className="d-flex flex-row justify-content-between">
+                <div className="flex-col pe-1" onClick={() => addNewCriteria(props.list.id, props.stateMgr, props.template.name)}>
+                    <p className="mb-0">{props.template.name}</p>
+                    <p className="mb-0 text-muted" style={{fontSize: '0.65em'}}>{props.template.type}</p>
+                </div>
+                <div className="flex-col">
+                    <Badge pill bg="danger" onClick={() => deleteCriteriaTemplate(props.template.name, props.stateMgr)}>
+                        <BootstrapIcon icon="trash" />
+                    </Badge>
+                    <div className="flex-grow-1"> </div>
+                </div>
+            </div>
+        </Dropdown.Item>
+    );
+}

--- a/src/components/shortlist-it-entry-deletion-modal.tsx
+++ b/src/components/shortlist-it-entry-deletion-modal.tsx
@@ -33,28 +33,28 @@ function confirmDeletion(entryId: string, stateMgr: ShortlistItStateManager): vo
 }
 
 export function ShortlistItEntryDeletionModal(props: ShortlistItEntryDeletionModalProps) {
-    const criteriaId = props.stateMgr.state.entryToBeDeleted;
+    const entryId = props.stateMgr.state.entryToBeDeleted;
     let list: Shortlist;
     let entryDesc: string;
-    if (criteriaId) {
-        list = props.stateMgr.state.lists.find(l => l.entries.find(c => c.id === criteriaId) != null);
-        entryDesc = list.entries.find(l => l.id === criteriaId)?.description;
+    if (entryId) {
+        list = props.stateMgr.state.lists.find(l => l.entries.find(c => c.id === entryId) != null);
+        entryDesc = list?.entries.find(l => l.id === entryId)?.description;
     }
     return (
         <ShortlistItModal 
-            id={`delete-${criteriaId}`}
+            id={`delete-${entryId}`}
             variant="danger"
             heading="Warning!"
             dismissible={true}
-            show={!!(criteriaId && list && entryDesc)}
+            show={!!(entryId)}
             onClose={() => hideDeleteConfirmation(props.stateMgr)}>
             <p>
-            are you certain you want to delete Entry: <i>{entryDesc}</i> from list titled: <i>{list?.title}</i>? once deleted it can not be recovered.
+            are you certain you want to delete Entry: <i>{entryDesc ?? "''"}</i> from list titled: <i>{list?.title}</i>? once deleted it can not be recovered.
             </p>
             <hr />
             <div className="d-flex justify-content-end">
                 <Button onClick={() => {
-                    confirmDeletion(criteriaId, props.stateMgr);
+                    confirmDeletion(entryId, props.stateMgr);
                 }} variant="outline-danger">
                     DELETE
                 </Button>

--- a/src/components/shortlist-it-entry-deletion-modal.tsx
+++ b/src/components/shortlist-it-entry-deletion-modal.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { ShortlistItStateManager } from "../types/shortlist-it-state-manager";
+import { ShortlistItModal } from "./shortlist-it-modal";
+import { Button } from "react-bootstrap";
+import { store } from "../utilities/storage";
+import { Shortlist } from "../types/shortlist";
+
+type ShortlistItEntryDeletionModalProps = {
+    stateMgr: ShortlistItStateManager;
+};
+
+function hideDeleteConfirmation(stateMgr: ShortlistItStateManager) {
+    stateMgr.setState({
+        ...stateMgr.state,
+        entryToBeDeleted: null
+    });
+}
+
+function confirmDeletion(entryId: string, stateMgr: ShortlistItStateManager): void {
+    const listIndex = stateMgr.state.lists.findIndex(l => l.entries.find(c => c.id === entryId));
+    if (listIndex >= 0) {
+        const list = stateMgr.state.lists[listIndex];
+        const entryIndex = list.entries.findIndex(e => e.id === entryId);
+        if (entryIndex >= 0) {
+            list.entries.splice(entryIndex, 1);
+            store.set('lists', stateMgr.state.lists);
+            stateMgr.setState({
+                ...stateMgr.state,
+                entryToBeDeleted: null
+            });
+        }
+    }
+}
+
+export function ShortlistItEntryDeletionModal(props: ShortlistItEntryDeletionModalProps) {
+    const criteriaId = props.stateMgr.state.entryToBeDeleted;
+    let list: Shortlist;
+    let entryDesc: string;
+    if (criteriaId) {
+        list = props.stateMgr.state.lists.find(l => l.entries.find(c => c.id === criteriaId) != null);
+        entryDesc = list.entries.find(l => l.id === criteriaId)?.description;
+    }
+    return (
+        <ShortlistItModal 
+            id={`delete-${criteriaId}`}
+            variant="danger"
+            heading="Warning!"
+            dismissible={true}
+            show={!!(criteriaId && list && entryDesc)}
+            onClose={() => hideDeleteConfirmation(props.stateMgr)}>
+            <p>
+            are you certain you want to delete Entry: <i>{entryDesc}</i> from list titled: <i>{list?.title}</i>? once deleted it can not be recovered.
+            </p>
+            <hr />
+            <div className="d-flex justify-content-end">
+                <Button onClick={() => {
+                    confirmDeletion(criteriaId, props.stateMgr);
+                }} variant="outline-danger">
+                    DELETE
+                </Button>
+            </div>
+        </ShortlistItModal>
+    );
+}

--- a/src/components/shortlist-it-list-criteria-add-new-dropdown.tsx
+++ b/src/components/shortlist-it-list-criteria-add-new-dropdown.tsx
@@ -27,13 +27,15 @@ function addNewCriteria(listId: string, stateMgr: ShortlistItStateManager, templ
 }
 
 function deleteCriteriaTemplate(templateId: string, stateMgr: ShortlistItStateManager): void {
-    const criteriaTemplates = stateMgr.state.criteriaTemplates;
-    criteriaTemplates.delete(templateId);
-    store.set('criteriaTemplates', criteriaTemplates);
-    stateMgr.setState({
-        ...stateMgr.state,
-        criteriaTemplates: criteriaTemplates
-    });
+    if (confirm(`are you sure you want to delete Criteria Template: '${templateId}'?`)) {
+        const criteriaTemplates = stateMgr.state.criteriaTemplates;
+        criteriaTemplates.delete(templateId);
+        store.set('criteriaTemplates', criteriaTemplates);
+        stateMgr.setState({
+            ...stateMgr.state,
+            criteriaTemplates: criteriaTemplates
+        });
+    }
 }
 
 type ShortlistItListCriteriaAddNewDropdownProps = {
@@ -63,7 +65,7 @@ export default function ShortlistItListCriteriaAddNewDropdown(props: ShortlistIt
                                     return (
                                         <Dropdown.Item key={c.name} onClick={() => null}>
                                             <div className="d-flex flex-row justify-content-between">
-                                                <div className="flex-grow-1" onClick={() => addNewCriteria(props.list.id, props.stateMgr, c.name)}>
+                                                <div className="flex-grow-1 pe-1" onClick={() => addNewCriteria(props.list.id, props.stateMgr, c.name)}>
                                                     {c.name}
                                                 </div>
                                                 <Badge pill bg="danger">

--- a/src/components/shortlist-it-list-criteria-add-new-dropdown.tsx
+++ b/src/components/shortlist-it-list-criteria-add-new-dropdown.tsx
@@ -6,9 +6,9 @@ import { getList, updateList } from "../component-actions/list-actions";
 import { v4 } from "uuid";
 import { Shortlist } from "../types/shortlist";
 import { Criteria } from "../types/criteria/criteria";
-import { store } from "../utilities/storage";
+import ShortlistItCriteriaTemplateItem from "./shortlist-it-criteria-template-item";
 
-function addNewCriteria(listId: string, stateMgr: ShortlistItStateManager, templateId?: string): void {
+export function addNewCriteria(listId: string, stateMgr: ShortlistItStateManager, templateId?: string): void {
     const list = getList(listId, stateMgr);
     if (list) {
         let criteria: Criteria;
@@ -23,18 +23,6 @@ function addNewCriteria(listId: string, stateMgr: ShortlistItStateManager, templ
         }
         list.criteria.push(criteria);
         updateList(listId, list, stateMgr);
-    }
-}
-
-function deleteCriteriaTemplate(templateId: string, stateMgr: ShortlistItStateManager): void {
-    if (confirm(`are you sure you want to delete Criteria Template: '${templateId}'?`)) {
-        const criteriaTemplates = stateMgr.state.criteriaTemplates;
-        criteriaTemplates.delete(templateId);
-        store.set('criteriaTemplates', criteriaTemplates);
-        stateMgr.setState({
-            ...stateMgr.state,
-            criteriaTemplates: criteriaTemplates
-        });
     }
 }
 
@@ -61,20 +49,12 @@ export default function ShortlistItListCriteriaAddNewDropdown(props: ShortlistIt
                             <Dropdown.Toggle split variant="info" id="dropdown-split-basic" />
 
                             <Dropdown.Menu>
-                                {Array.from(props.stateMgr.state.criteriaTemplates.values()).map(c => {
-                                    return (
-                                        <Dropdown.Item key={c.name} onClick={() => null}>
-                                            <div className="d-flex flex-row justify-content-between">
-                                                <div className="flex-grow-1 pe-1" onClick={() => addNewCriteria(props.list.id, props.stateMgr, c.name)}>
-                                                    {c.name}
-                                                </div>
-                                                <Badge pill bg="danger">
-                                                    <BootstrapIcon icon="trash" onClick={() => deleteCriteriaTemplate(c.name, props.stateMgr)} />
-                                                </Badge>
-                                            </div>
-                                        </Dropdown.Item>
-                                    );
-                                })}
+                                {Array.from(props.stateMgr.state.criteriaTemplates.values()).map(c => <ShortlistItCriteriaTemplateItem 
+                                    key={c.name}
+                                    list={props.list}
+                                    stateMgr={props.stateMgr}
+                                    template={c}
+                                />)}
                             </Dropdown.Menu>
                         </>) : <></>
                     }

--- a/src/components/shortlist-it-list-criteria-add-new-dropdown.tsx
+++ b/src/components/shortlist-it-list-criteria-add-new-dropdown.tsx
@@ -1,24 +1,39 @@
 import React from "react";
-import { Button, ButtonGroup, Dropdown, DropdownButton, ListGroupItem } from "react-bootstrap";
+import { Badge, Button, ButtonGroup, Dropdown, ListGroupItem } from "react-bootstrap";
 import { BootstrapIcon } from "./bootstrap-icon";
 import { ShortlistItStateManager } from "../types/shortlist-it-state-manager";
 import { getList, updateList } from "../component-actions/list-actions";
 import { v4 } from "uuid";
 import { Shortlist } from "../types/shortlist";
 import { Criteria } from "../types/criteria/criteria";
+import { store } from "../utilities/storage";
 
 function addNewCriteria(listId: string, stateMgr: ShortlistItStateManager, templateId?: string): void {
     const list = getList(listId, stateMgr);
     if (list) {
         let criteria: Criteria;
-        if (templateId) {
-
-        } else {
+        if (templateId && stateMgr.state.criteriaTemplates.has(templateId)) {
+            criteria = {
+                id: v4(),
+                ...stateMgr.state.criteriaTemplates.get(templateId)
+            };
+        }
+        if (!criteria) {
             criteria = {id: v4(), values: new Array<string>(), weight: 1};
         }
         list.criteria.push(criteria);
         updateList(listId, list, stateMgr);
     }
+}
+
+function deleteCriteriaTemplate(templateId: string, stateMgr: ShortlistItStateManager): void {
+    const criteriaTemplates = stateMgr.state.criteriaTemplates;
+    criteriaTemplates.delete(templateId);
+    store.set('criteriaTemplates', criteriaTemplates);
+    stateMgr.setState({
+        ...stateMgr.state,
+        criteriaTemplates: criteriaTemplates
+    });
 }
 
 type ShortlistItListCriteriaAddNewDropdownProps = {
@@ -34,19 +49,33 @@ export default function ShortlistItListCriteriaAddNewDropdown(props: ShortlistIt
                 key={`add_new_criteria_${props.list.id}`}
                 className="d-flex justify-content-center"
             >
-                <Dropdown as={ButtonGroup}>
+                <Dropdown as={ButtonGroup} align="start">
                     <Button variant="info" onClick={() => addNewCriteria(props.list.id, props.stateMgr)}>
                         <BootstrapIcon icon="plus-lg" /> 
                         Add New Criteria
                     </Button>
+                    {(props.stateMgr.state.criteriaTemplates.size > 0) ? (
+                        <>
+                            <Dropdown.Toggle split variant="info" id="dropdown-split-basic" />
 
-                    <Dropdown.Toggle split variant="info" id="dropdown-split-basic" />
-
-                    <Dropdown.Menu>
-                        <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
-                        <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
-                        <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
-                    </Dropdown.Menu>
+                            <Dropdown.Menu>
+                                {Array.from(props.stateMgr.state.criteriaTemplates.values()).map(c => {
+                                    return (
+                                        <Dropdown.Item key={c.name} onClick={() => null}>
+                                            <div className="d-flex flex-row justify-content-between">
+                                                <div className="flex-grow-1" onClick={() => addNewCriteria(props.list.id, props.stateMgr, c.name)}>
+                                                    {c.name}
+                                                </div>
+                                                <Badge pill bg="danger">
+                                                    <BootstrapIcon icon="trash" onClick={() => deleteCriteriaTemplate(c.name, props.stateMgr)} />
+                                                </Badge>
+                                            </div>
+                                        </Dropdown.Item>
+                                    );
+                                })}
+                            </Dropdown.Menu>
+                        </>) : <></>
+                    }
                 </Dropdown>
                 
             </ListGroupItem>

--- a/src/components/shortlist-it-list-criteria-add-new-dropdown.tsx
+++ b/src/components/shortlist-it-list-criteria-add-new-dropdown.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Badge, Button, ButtonGroup, Dropdown, ListGroupItem } from "react-bootstrap";
+import { Button, ButtonGroup, Dropdown, ListGroupItem } from "react-bootstrap";
 import { BootstrapIcon } from "./bootstrap-icon";
 import { ShortlistItStateManager } from "../types/shortlist-it-state-manager";
 import { getList, updateList } from "../component-actions/list-actions";

--- a/src/components/shortlist-it-list-criteria-add-new-dropdown.tsx
+++ b/src/components/shortlist-it-list-criteria-add-new-dropdown.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { Button, ButtonGroup, Dropdown, DropdownButton, ListGroupItem } from "react-bootstrap";
+import { BootstrapIcon } from "./bootstrap-icon";
+import { ShortlistItStateManager } from "../types/shortlist-it-state-manager";
+import { getList, updateList } from "../component-actions/list-actions";
+import { v4 } from "uuid";
+import { Shortlist } from "../types/shortlist";
+import { Criteria } from "../types/criteria/criteria";
+
+function addNewCriteria(listId: string, stateMgr: ShortlistItStateManager, templateId?: string): void {
+    const list = getList(listId, stateMgr);
+    if (list) {
+        let criteria: Criteria;
+        if (templateId) {
+
+        } else {
+            criteria = {id: v4(), values: new Array<string>(), weight: 1};
+        }
+        list.criteria.push(criteria);
+        updateList(listId, list, stateMgr);
+    }
+}
+
+type ShortlistItListCriteriaAddNewDropdownProps = {
+    stateMgr: ShortlistItStateManager;
+    list: Shortlist;
+};
+
+export default function ShortlistItListCriteriaAddNewDropdown(props: ShortlistItListCriteriaAddNewDropdownProps) {
+    return (
+        <>
+            <ListGroupItem
+                variant="info"
+                key={`add_new_criteria_${props.list.id}`}
+                className="d-flex justify-content-center"
+            >
+                <Dropdown as={ButtonGroup}>
+                    <Button variant="info" onClick={() => addNewCriteria(props.list.id, props.stateMgr)}>
+                        <BootstrapIcon icon="plus-lg" /> 
+                        Add New Criteria
+                    </Button>
+
+                    <Dropdown.Toggle split variant="info" id="dropdown-split-basic" />
+
+                    <Dropdown.Menu>
+                        <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
+                        <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
+                        <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
+                    </Dropdown.Menu>
+                </Dropdown>
+                
+            </ListGroupItem>
+        </>
+    );
+}

--- a/src/components/shortlist-it-list-criteria-list-item.tsx
+++ b/src/components/shortlist-it-list-criteria-list-item.tsx
@@ -71,6 +71,10 @@ function validateWeight(props: ShortlistItListCriteriaListItemProps, state: Shor
     });
 }
 
+function saveAsTemplate(listId: string, criteriaId: string, stateMgr: ShortlistItStateManager): void {
+
+}
+
 function deleteCriteria(listId: string, criteriaId: string, stateMgr: ShortlistItStateManager): void {
     const list = getList(listId, stateMgr);
     if (list) {
@@ -152,6 +156,11 @@ export function ShortlistItListCriteriaListItem(props: ShortlistItListCriteriaLi
                 </div>
             </div>
             <div className="d-flex flex-column justify-content-between ps-1">
+                <ShortlistItTooltip id={`save-criteria-template-${props.criteria.id}`} text="Save as Template">
+                    <Button variant="info" onClick={() => saveAsTemplate(props.list.id, props.criteria.id, props.stateMgr)}>
+                        <BootstrapIcon icon="file-earmark-arrow-down" />
+                    </Button>
+                </ShortlistItTooltip>
                 <ShortlistItTooltip id={`delete-criteria-${props.criteria.id}`} text="Delete Criteria">
                     <Button variant="danger" onClick={() => deleteCriteria(props.list.id, props.criteria.id, props.stateMgr)}>
                         <BootstrapIcon icon="trash" />

--- a/src/components/shortlist-it-list-criteria-list-item.tsx
+++ b/src/components/shortlist-it-list-criteria-list-item.tsx
@@ -7,7 +7,6 @@ import { Shortlist } from "../types/shortlist";
 import { BootstrapIcon } from "./bootstrap-icon";
 import { ShortlistItTooltip } from "./shortlist-it-tooltip";
 import { ShortlistItStateManager } from "../types/shortlist-it-state-manager";
-import { getList, updateList } from "../component-actions/list-actions";
 import { store } from "../utilities/storage";
 
 type ShortlistItListCriteriaListItemProps = {
@@ -123,19 +122,11 @@ function validateCriteriaTemplateValues(criteriaRef: CriteriaRefContainer): Omit
     };
 }
 
-function deleteCriteria(listId: string, criteriaId: string, stateMgr: ShortlistItStateManager): void {
-    const list = getList(listId, stateMgr);
-    if (list) {
-        const index = list.criteria.findIndex(c => c.id === criteriaId);
-        if (index >= 0) {
-            const criteria = list.criteria[index];
-            const confirmed: boolean = window.confirm(`are you sure you want to delete criteria: '${criteria.name}' from list '${list.title}'? this action cannot be undone and will remove all values associated with the criteria from any entries in the list`)
-            if (confirmed) {
-                list.criteria.splice(index, 1);
-                updateList(listId, list, stateMgr);
-            }
-        }
-    }
+function deleteCriteria(criteriaId: string, stateMgr: ShortlistItStateManager): void {
+    stateMgr.setState({
+        ...stateMgr.state,
+        criteriaToBeDeleted: criteriaId
+    });
 }
 
 export function ShortlistItListCriteriaListItem(props: ShortlistItListCriteriaListItemProps) {
@@ -210,7 +201,7 @@ export function ShortlistItListCriteriaListItem(props: ShortlistItListCriteriaLi
                     </Button>
                 </ShortlistItTooltip>
                 <ShortlistItTooltip id={`delete-criteria-${props.criteria.id}`} text="Delete Criteria">
-                    <Button variant="danger" onClick={() => deleteCriteria(props.list.id, props.criteria.id, props.stateMgr)}>
+                    <Button variant="danger" onClick={() => deleteCriteria(props.criteria.id, props.stateMgr)}>
                         <BootstrapIcon icon="trash" />
                     </Button>
                 </ShortlistItTooltip>

--- a/src/components/shortlist-it-list-criteria-list.tsx
+++ b/src/components/shortlist-it-list-criteria-list.tsx
@@ -1,13 +1,11 @@
 import React from "react";
-import { ListGroup, ListGroupItem } from "react-bootstrap";
+import { ListGroup } from "react-bootstrap";
 import { Criteria } from "../types/criteria/criteria";
 import { Shortlist } from "../types/shortlist";
-import { BootstrapIcon } from "./bootstrap-icon";
 import { ShortlistItListCriteriaListItem } from "./shortlist-it-list-criteria-list-item";
 import { CriteriaRefContainer } from "../types/criteria/criteria-ref-container";
-import { v4 } from "uuid";
 import { ShortlistItStateManager } from "../types/shortlist-it-state-manager";
-import { getList, updateList } from "../component-actions/list-actions";
+import ShortlistItListCriteriaAddNewDropdown from "./shortlist-it-list-criteria-add-new-dropdown";
 
 type ShortlistItListCriteriaListProps = {
     stateMgr: ShortlistItStateManager;
@@ -15,14 +13,6 @@ type ShortlistItListCriteriaListProps = {
     criteria: Array<Criteria>;
     criteriaRefs: Array<CriteriaRefContainer>
 };
-
-function addNewCriteria(listId: string, stateMgr: ShortlistItStateManager): void {
-    const list = getList(listId, stateMgr);
-    if (list) {
-        list.criteria.push({id: v4(), values: new Array<string>(), weight: 1});
-        updateList(listId, list, stateMgr);
-    }
-}
 
 export function ShortlistItListCriteriaList(props: ShortlistItListCriteriaListProps) {
     return (
@@ -34,14 +24,10 @@ export function ShortlistItListCriteriaList(props: ShortlistItListCriteriaListPr
                 criteria={c} 
                 criteriaRef={props.criteriaRefs.find(r => r.id === c.id)} />
             )}
-            <ListGroupItem
-                variant="info"
-                key="add_new_criteria" 
-                onClick={() => addNewCriteria(props.list.id, props.stateMgr)}
-                className="d-flex justify-content-center clickable">
-                <BootstrapIcon icon="plus-lg" /> 
-                Add New Criteria
-            </ListGroupItem>
+            <ShortlistItListCriteriaAddNewDropdown
+                stateMgr={props.stateMgr}
+                list={props.list}
+            />
         </ListGroup>
     );
 }

--- a/src/components/shortlist-it-list-deletion-modal.tsx
+++ b/src/components/shortlist-it-list-deletion-modal.tsx
@@ -12,7 +12,7 @@ type ShortlistItListDeletionModalProps = {
 function hideDeleteConfirmation(stateMgr: ShortlistItStateManager) {
     stateMgr.setState({
         ...stateMgr.state,
-        listToBeDeleted: undefined
+        listToBeDeleted: null
     });
 }
 
@@ -24,13 +24,14 @@ function confirmDeletion(listId: string, stateMgr: ShortlistItStateManager): voi
         store.set('lists', tmp);
         stateMgr.setState({
             ...stateMgr.state,
-            lists: tmp
+            lists: tmp,
+            listToBeDeleted: null
         });
     }
 }
 
 export function ShortlistItListDeletionModal(props: ShortlistItListDeletionModalProps) {
-    const listId = props.stateMgr.state.listToBeDeleted ?? '';
+    const listId = props.stateMgr.state.listToBeDeleted;
     const listTitle = props.stateMgr.state.lists.find(l => l.id === listId)?.title;
     return (
         <ShortlistItModal 
@@ -41,19 +42,17 @@ export function ShortlistItListDeletionModal(props: ShortlistItListDeletionModal
             show={!!(listId && listTitle)}
             onClose={() => hideDeleteConfirmation(props.stateMgr)}>
             <p>
-            are you certain you want to delete list titled: <i>{listTitle}</i> a deleted list can not be recovered. 
+            are you certain you want to delete list titled: <i>{listTitle}</i>? a deleted list can not be recovered. 
             would you rather archive this list instead?
             </p>
             <hr />
             <div className="d-flex justify-content-between">
                 <Button onClick={() => {
-                    hideDeleteConfirmation(props.stateMgr);
                     archiveList(listId, props.stateMgr);
                 }} variant="outline-dark">
                     Archive
                 </Button>
                 <Button onClick={() => {
-                    hideDeleteConfirmation(props.stateMgr);;
                     confirmDeletion(listId, props.stateMgr);
                 }} variant="outline-danger">
                     DELETE

--- a/src/components/shortlist-it-list-entry.tsx
+++ b/src/components/shortlist-it-list-entry.tsx
@@ -48,7 +48,7 @@ function getEditButton(props: ShortlistItListEntryProps, descRefObject: React.Re
                         </Button>
                     </ShortlistItTooltip>
                     <ShortlistItTooltip id={`delete-entry-${props.entry.id}`} text="Delete Entry" className="mt-2">
-                        <Button variant="danger" onClick={() => deleteEntry(props.list.id, props.entry.id, props.stateMgr)}>
+                        <Button variant="danger" onClick={() => deleteEntry(props.entry.id, props.stateMgr)}>
                             <BootstrapIcon icon="trash" />
                         </Button>
                     </ShortlistItTooltip>
@@ -151,18 +151,11 @@ function cancelListEntryEdits(listId: string, entryId: string, stateMgr: Shortli
     setEditingListEntryState(listId, entryId, false, stateMgr);
 }
 
-function deleteEntry(listId: string, entryId: string, stateMgr: ShortlistItStateManager): void {
-    const list = getList(listId, stateMgr);
-    const entry = getEntry(listId, entryId, stateMgr);
-    const confirmed: boolean = window.confirm(`Are you sure you want to delete entry described by: '${entry.description}' from list '${list.title}'? This action cannot be undone.`);
-    if (confirmed) {
-        const index = list.entries.findIndex(e => e.id === entryId);
-        if (index >= 0) {
-            let updated = list;
-            updated.entries.splice(index, 1);
-            updateList(listId, updated, stateMgr);
-        }
-    }
+function deleteEntry(entryId: string, stateMgr: ShortlistItStateManager): void {
+    stateMgr.setState({
+        ...stateMgr.state,
+        entryToBeDeleted: entryId
+    });
 }
 
 export function ShortlistItListEntry(props: ShortlistItListEntryProps) {

--- a/src/components/shortlist-it-modal.tsx
+++ b/src/components/shortlist-it-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { createRef, useEffect } from "react";
 import { Alert } from "react-bootstrap";
 
 type ShortlistItModalProps = JSX.ElementChildrenAttribute & {
@@ -9,18 +9,6 @@ type ShortlistItModalProps = JSX.ElementChildrenAttribute & {
     heading: string;
     onClose: () => void;
 };
-
-type ShortlistItModalState = {
-    show: boolean;
-}
-
-function scrollToTop(): void {
-    const html = document.querySelector("html");
-    html.scrollTo({
-        top: 0,
-        behavior: 'instant' as ScrollBehavior
-    });
-}
 
 function preventScrolling(): void {
     const html = document.querySelector("html");
@@ -37,23 +25,34 @@ function restoreScrolling(): void {
 }
 
 export function ShortlistItModal(props: ShortlistItModalProps) {
-    const [state, setState] = useState<ShortlistItModalState>({
-        show: props.show ?? true
-    });
+    const overlayRef = createRef<HTMLDivElement>();
+
+    useEffect(() => {
+        if (overlayRef.current) {
+            preventScrolling();
+            window.setTimeout(() => window.scrollTo({top: 0, behavior: 'instant' as ScrollBehavior}), 100);
+        } else {
+            restoreScrolling();
+        }
+    }, [props.show]);
     
     if (props.show) {
-        scrollToTop();
-        preventScrolling();
         return (
             <div className="overlay w-100 d-flex justify-content-center align-content-start">
-                <Alert className="m-3" id={props.id} variant={props.variant} dismissible={props.dismissible} onClose={() => props.onClose()}>
+                <Alert
+                    ref={overlayRef}
+                    className="m-3"
+                    id={props.id}
+                    variant={props.variant}
+                    dismissible={props.dismissible}
+                    onClose={() => props.onClose()}
+                >
                     <Alert.Heading>{props.heading}</Alert.Heading>
                     {props.children}
                 </Alert>
             </div>
         );
     } else {
-        restoreScrolling();
         return <></>;
     }
 }

--- a/src/components/shortlist-it-modal.tsx
+++ b/src/components/shortlist-it-modal.tsx
@@ -14,6 +14,14 @@ type ShortlistItModalState = {
     show: boolean;
 }
 
+function scrollToTop(): void {
+    const html = document.querySelector("html");
+    html.scrollTo({
+        top: 0,
+        behavior: 'instant' as ScrollBehavior
+    });
+}
+
 function preventScrolling(): void {
     const html = document.querySelector("html");
     if (html) {
@@ -34,6 +42,7 @@ export function ShortlistItModal(props: ShortlistItModalProps) {
     });
     
     if (props.show) {
+        scrollToTop();
         preventScrolling();
         return (
             <div className="overlay w-100 d-flex justify-content-center align-content-start">

--- a/src/components/shortlist-it.tsx
+++ b/src/components/shortlist-it.tsx
@@ -9,6 +9,8 @@ import { ShortlistItList } from "./shortlist-it-list";
 import { ShortlistItNav } from "./shortlist-it-nav";
 import { ShortlistItState } from "../types/shortlist-it-state";
 import { ShortlistItListDeletionModal } from "./shortlist-it-list-deletion-modal";
+import { ShortlistItCriteriaDeletionModal } from "./shortlist-it-criteria-deletion-modal";
+import { ShortlistItEntryDeletionModal } from "./shortlist-it-entry-deletion-modal";
 
 function getLists(state: ShortlistItState): Array<Shortlist> {
     let lists = state.lists;
@@ -156,6 +158,8 @@ export function ShortlistIt() {
     return (
         <>
             <ShortlistItListDeletionModal stateMgr={{state, setState}} />
+            <ShortlistItEntryDeletionModal stateMgr={{state, setState}} />
+            <ShortlistItCriteriaDeletionModal stateMgr={{state, setState}} />
             <ShortlistItNav stateMgr={{state, setState}} />
             <div className="d-flex justify-content-evenly align-items-start flex-wrap flex-sm-row flex-column">
                 {lists.map((list) => <ShortlistItList key={list.id} stateMgr={{state, setState}} list={list} />)}

--- a/src/components/shortlist-it.tsx
+++ b/src/components/shortlist-it.tsx
@@ -11,6 +11,7 @@ import { ShortlistItState } from "../types/shortlist-it-state";
 import { ShortlistItListDeletionModal } from "./shortlist-it-list-deletion-modal";
 import { ShortlistItCriteriaDeletionModal } from "./shortlist-it-criteria-deletion-modal";
 import { ShortlistItEntryDeletionModal } from "./shortlist-it-entry-deletion-modal";
+import { ShortlistItCriteriaTemplateDeletionModal } from "./shortlist-it-criteria-template-deletion-modal";
 
 function getLists(state: ShortlistItState): Array<Shortlist> {
     let lists = state.lists;
@@ -160,6 +161,7 @@ export function ShortlistIt() {
             <ShortlistItListDeletionModal stateMgr={{state, setState}} />
             <ShortlistItEntryDeletionModal stateMgr={{state, setState}} />
             <ShortlistItCriteriaDeletionModal stateMgr={{state, setState}} />
+            <ShortlistItCriteriaTemplateDeletionModal stateMgr={{state, setState}} />
             <ShortlistItNav stateMgr={{state, setState}} />
             <div className="d-flex justify-content-evenly align-items-start flex-wrap flex-sm-row flex-column">
                 {lists.map((list) => <ShortlistItList key={list.id} stateMgr={{state, setState}} list={list} />)}

--- a/src/components/shortlist-it.tsx
+++ b/src/components/shortlist-it.tsx
@@ -147,7 +147,8 @@ export function ShortlistIt() {
         lists: store.get('lists', new Array<Shortlist>(...exampleLists)),
         filterText: store.get('filterText', ''),
         editingListMap: new Map<string, boolean>(),
-        editingListEntryMap: new Map<string, boolean>()
+        editingListEntryMap: new Map<string, boolean>(),
+        criteriaTemplates: store.get('criteriaTemplates', new Map<string, Omit<Criteria, 'id'>>())
     });
 
     const lists: Array<Shortlist> = getLists(state);

--- a/src/index.css
+++ b/src/index.css
@@ -29,8 +29,8 @@ body {
   position: absolute;
   top: 0px;
   left: 0px;
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
   justify-content: center;
   align-items: center;
   background: rgba(0, 0, 0, 0.5);

--- a/src/types/shortlist-it-state.ts
+++ b/src/types/shortlist-it-state.ts
@@ -5,6 +5,8 @@ export type ShortlistItState = {
     lists: Array<Shortlist>,
     showArchived: boolean,
     listToBeDeleted?: string;
+    criteriaToBeDeleted?: string;
+    entryToBeDeleted?: string;
     filterText: string;
     editingListMap: Map<string, boolean>
     editingListEntryMap: Map<string, boolean>

--- a/src/types/shortlist-it-state.ts
+++ b/src/types/shortlist-it-state.ts
@@ -1,3 +1,4 @@
+import { Criteria } from "./criteria/criteria";
 import { Shortlist } from "./shortlist";
 
 export type ShortlistItState = {
@@ -7,4 +8,5 @@ export type ShortlistItState = {
     filterText: string;
     editingListMap: Map<string, boolean>
     editingListEntryMap: Map<string, boolean>
+    criteriaTemplates: Map<string, Omit<Criteria, 'id'>>
 };

--- a/src/types/shortlist-it-state.ts
+++ b/src/types/shortlist-it-state.ts
@@ -6,6 +6,7 @@ export type ShortlistItState = {
     showArchived: boolean,
     listToBeDeleted?: string;
     criteriaToBeDeleted?: string;
+    criteriaTemplateToBeDeleted?: string;
     entryToBeDeleted?: string;
     filterText: string;
     editingListMap: Map<string, boolean>

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -95,8 +95,17 @@ export class Storage {
             if (containers?.length) {
                 container = containers.find(c => c.version === this.version);
                 if (!container) {
-                    container = containers.find(c => c.version.match(/^(1\.)([0-9]+\.)([0-9]+)$/));
-                    if (container) {
+                    const sameMajorVersion = containers.sort((a, b) => {
+                        if (a.version < b.version) {
+                            return 1;
+                        }
+                        if (a.version > b.version) {
+                            return -1;
+                        }
+                        return 0;
+                    }).find(c => c.version.match(/^(1\.)([0-9]+\.)([0-9]+)$/));
+                    if (sameMajorVersion) {
+                        container = {...sameMajorVersion, version: this.version};
                         (container.data.get('lists') as Array<Shortlist>).forEach(l => l.criteria.forEach(c => c.weight ??= 1));
                     }
                 }


### PR DESCRIPTION
**Changes**:
- adds ability to save Criteria for re-use in other lists
- replaces native window alert and confirm calls for Entry, Criteria and Criteria Template deletion with HTML modals